### PR TITLE
Point getting sources to pull request workflow

### DIFF
--- a/development/compiling/getting_source.rst
+++ b/development/compiling/getting_source.rst
@@ -15,6 +15,9 @@ The source code is available on `GitHub <https://github.com/godotengine/godot>`_
 and while you can manually download it via the website, in general you want to
 do it via the ``git`` version control system.
 
+If you are compiling in order to make contributions or pull requests, you should  
+follow the instructions for the :ref:`pull request workflow <doc_pr_workflow>`.
+
 If you don't know much about ``git`` yet, there are a great number of
 `tutorials <https://git-scm.com/book>`__ available on various websites.
 


### PR DESCRIPTION
Potential contributors can land on the building instructions before the PR instructions.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
